### PR TITLE
Switch from build to assemble task

### DIFF
--- a/colcon_gradle/task/gradle/build.py
+++ b/colcon_gradle/task/gradle/build.py
@@ -69,6 +69,6 @@ class GradleBuildTask(TaskExtensionPoint):
         if args.gradle_task:
             cmd += [args.gradle_task]
         else:
-            cmd += ['build']
+            cmd += ['assemble']
         return await check_call(
             self.context, cmd, cwd=args.build_base, env=env)


### PR DESCRIPTION
Preferred 'assemble' to 'build' task in Gradle.

by default 'build' task run 'test' task. But colcon separate two task.
```
:build
+--- :assemble
|    \--- :jar
|         \--- :classes
|              +--- :compileJava
|              \--- :processResources
\--- :check
     \--- :test
          +--- :classes
          |    +--- :compileJava
          |    \--- :processResources
          \--- :testClasses
               +--- :compileTestJava
               |    \--- :classes
               |         +--- :compileJava
               |         \--- :processResources
               \--- :processTestResources
```
Or for exclude the test `gradle build -x test `