### PR TITLE
Split gradle arguments

### DIFF
--- a/colcon_gradle/task/gradle/build.py
+++ b/colcon_gradle/task/gradle/build.py
@@ -81,7 +81,8 @@ class GradleBuildTask(TaskExtensionPoint):
 
         # Gradle Arguments
         if args.gradle_args:
-            cmd += args.gradle_args[0].split()
+            for arg in args.gradle_args:
+                cmd += arg.split()
 
         # invoke build step
         return await check_call(

--- a/colcon_gradle/task/gradle/build.py
+++ b/colcon_gradle/task/gradle/build.py
@@ -80,7 +80,8 @@ class GradleBuildTask(TaskExtensionPoint):
             cmd += ['assemble']
 
         # Gradle Arguments
-        cmd += args.gradle_args
+        if args.gradle_args:
+            cmd += args.gradle_args[0].split()
 
         # invoke build step
         return await check_call(


### PR DESCRIPTION
When many arguments is pass by `--gradle_args`, generate :
`cmd = ['~/rosjava_ws/src/ros2_java/ros2_java_examples/rcljava_examples/gradlew', 'assemble', '--parallel --daemon --configure-on-demand --stacktrace', '-Pament.install_space=...', '-Pament.dependencies=...']`
but is not apply in gradle...

need to be
`cmd = ['~/rosjava_ws/src/ros2_java/ros2_java_examples/rcljava_examples/gradlew', 'assemble', '--parallel', '--daemon', '--configure-on-demand', '--stacktrace', '-Pament.install_space=...', '-Pament.dependencies=...']`

_Not sure about solution..._