### PR TITLE
Replace deprecated colcon_core.task.check_call() with colcon_core.task.run()

### DIFF
--- a/colcon_gradle/task/gradle/build.py
+++ b/colcon_gradle/task/gradle/build.py
@@ -10,7 +10,7 @@ from colcon_core.environment import create_environment_scripts
 from colcon_core.logging import colcon_logger
 from colcon_core.plugin_system import satisfies_version
 from colcon_core.shell import get_command_environment
-from colcon_core.task import check_call
+from colcon_core.task import run
 from colcon_core.task import TaskExtensionPoint
 from colcon_gradle.task.gradle import get_wrapper_executable
 from colcon_gradle.task.gradle import GRADLE_EXECUTABLE
@@ -126,7 +126,7 @@ class GradleBuildTask(TaskExtensionPoint):
         cmd += ['--stacktrace']
 
         # invoke build step
-        return await check_call(
+        return await run(
             self.context, cmd, cwd=args.build_base, env=env)
 
     async def _install(self, args, env):

--- a/colcon_gradle/task/gradle/test.py
+++ b/colcon_gradle/task/gradle/test.py
@@ -4,7 +4,6 @@
 from colcon_core.logging import colcon_logger
 from colcon_core.plugin_system import satisfies_version
 from colcon_core.shell import get_command_environment
-from colcon_core.subprocess import check_output
 from colcon_core.task import run
 from colcon_core.task import TaskExtensionPoint
 from colcon_gradle.task.gradle import get_wrapper_executable

--- a/colcon_gradle/task/gradle/test.py
+++ b/colcon_gradle/task/gradle/test.py
@@ -4,7 +4,8 @@
 from colcon_core.logging import colcon_logger
 from colcon_core.plugin_system import satisfies_version
 from colcon_core.shell import get_command_environment
-from colcon_core.task import check_call
+from colcon_core.subprocess import check_output
+from colcon_core.task import run
 from colcon_core.task import TaskExtensionPoint
 from colcon_gradle.task.gradle import get_wrapper_executable
 from colcon_gradle.task.gradle import GRADLE_EXECUTABLE
@@ -74,5 +75,5 @@ class GradleTestTask(TaskExtensionPoint):
             cmd += args.gradletest_args
 
         # invoke build step
-        return await check_call(
+        return await run(
             self.context, cmd, cwd=args.build_base, env=env)


### PR DESCRIPTION
`check_call()` was deprecated and renamed `run()`, see also https://github.com/colcon/colcon-core/pull/334.