### PR TITLE
Return a str in which_executable()

### DIFF
--- a/colcon_gradle/task/gradle/__init__.py
+++ b/colcon_gradle/task/gradle/__init__.py
@@ -52,7 +52,7 @@ def which_executable(environment_variable, executable_name):
     if cmd is None:
         cmd = shutil.which(executable_name)
 
-    return cmd
+    return str(cmd)
 
 
 GRADLE_EXECUTABLE = which_executable(

--- a/colcon_gradle/task/gradle/__init__.py
+++ b/colcon_gradle/task/gradle/__init__.py
@@ -46,13 +46,13 @@ def which_executable(environment_variable, executable_name):
     if cmd is None and env_home is not None:
         gradle_path = Path(env_home) / 'bin' / executable_name
         if gradle_path.is_file():
-            cmd = gradle_path
+            cmd = str(gradle_path)
 
     # fallback (from PATH)
     if cmd is None:
         cmd = shutil.which(executable_name)
 
-    return str(cmd)
+    return cmd
 
 
 GRADLE_EXECUTABLE = which_executable(


### PR DESCRIPTION
I'm sometimes getting the following error:

```
Traceback (most recent call last):                                                                                                                                                                          
  File "/usr/lib/python3/dist-packages/colcon_core/event_reactor.py", line 78, in _notify_observers                                                                                                         
    retval = observer(event)                                                                                                                                                                                
  File "/usr/lib/python3/dist-packages/colcon_output/event_handler/log.py", line 107, in __call__                                                                                                           
    line = data.to_string() + '\n'                                                                                                                                                                          
  File "/usr/lib/python3/dist-packages/colcon_core/event/command.py", line 38, in to_string                                                                                                                 
    string += self._get_cmd_string()                                                                                                                                                                        
  File "/usr/lib/python3/dist-packages/colcon_core/event/command.py", line 84, in _get_cmd_string                                                                                                           
    return ' '.join([                                                                                                                                                                                       
TypeError: sequence item 0: expected str instance, PosixPath found
```

This was because `colcon_core` failing to log the gradle path.
The error doesn't always happen, it depends on how gradle is found (and thus, how gradle is installed)